### PR TITLE
Update README.md with tip on project references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 In order to publish new releases from this fork, we have renamed this project to
 `rn-fetch-blob` and published to `https://www.npmjs.com/package/rn-fetch-blob`.
 
+**Note**: If upgrading from the original fork change all references in your project from `react-native-fetch-blob` to `rn-fetch-blob`.  This includes `*.xcodeproj/project.pbxproj` and `android/**/*.gradle` depending on the platform used, failing to do so may cause build errors.
+
 # rn-fetch-blob
 [![release](https://img.shields.io/github/release/joltup/rn-fetch-blob.svg?style=flat-square)](https://github.com/joltup/rn-fetch-blob/releases) [![npm](https://img.shields.io/npm/v/rn-fetch-blob.svg?style=flat-square)](https://www.npmjs.com/package/rn-fetch-blob) ![](https://img.shields.io/badge/PR-Welcome-brightgreen.svg?style=flat-square) [![](https://img.shields.io/badge/Wiki-Public-brightgreen.svg?style=flat-square)](https://github.com/joltup/rn-fetch-blob/wiki) [![npm](https://img.shields.io/npm/l/rn-fetch-blob.svg?maxAge=2592000&style=flat-square)]()
 


### PR DESCRIPTION
Wanted to include a note for folks upgrading from the old branch to the new branch about renaming all product references as this was a problem I came across in #122 (https://github.com/joltup/rn-fetch-blob/issues/122)